### PR TITLE
make linking work in "place with space" on Windows

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ $hash{PM}{$_} = "\$(INST_LIBDIR)/Prima/$_" for glob 'pod/*.png';
 
 # Link to Prima's dynamic library if there are any linker settings.
 # (Big shout out to Dmitry, Rob, and Chris for helping me solve this!!)
-$hash{LIBS}[0] .= " $Prima::Config::Config{libs}"
+$hash{LIBS}[0] .= qq{ "$Prima::Config::Config{libs}"} # for "place with space"
 	if $Prima::Config::Config{libs};
 
 WriteMakefile(


### PR DESCRIPTION
As realised in investigating https://github.com/PDLPorters/PDL-Graphics-Prima/pull/50, if Perl is installed in a "place with space" (a directory with a space in its name), this module doesn't work on Windows, because it doesn't quote-protect `$Prima::Config::Config{libs}`. This PR fixes that, and makes this module build successfully for my awkward setup.

It would probably be even better to make Prima-using libraries behave the same on Windows and Unix, possibly using a similar scheme to PDL (a `$PDL::SHARE` with a pointer to a C struct).