### PR TITLE
Fix Makefile.PL: Bugtracker location

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -45,7 +45,7 @@ WriteMakefile(
 				web  => 'https://github.com/dk/PDL-Drawing-Prima',
 			},
 			bugtracker   => {
-				web  => 'https://github.com/PDLPorters/PDL-Drawing-Prima/issues',
+				web  => 'https://github.com/dk/PDL-Drawing-Prima/issues',
 			},
 		},
 		no_index => {

--- a/t/00-load-main.t
+++ b/t/00-load-main.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More tests => 1;
 use Prima::noX11;
+use Prima;
 
 BEGIN {
     use_ok( 'PDL::Drawing::Prima' )

--- a/t/01-load-utils.t
+++ b/t/01-load-utils.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More tests => 1;
 use Prima::noX11;
+use Prima;
 
 BEGIN {
     use_ok( 'PDL::Drawing::Prima::Utils' )


### PR DESCRIPTION
The repository is at @dk, not at @PDLPorters, the commit makes Makefile.PL point to it.